### PR TITLE
fix: use lodash random in square.v1 script

### DIFF
--- a/src/js/square.v1.js
+++ b/src/js/square.v1.js
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash';
+import { random } from 'lodash';
 
 //function Square() {
   const canvas = document.querySelector('canvas');
@@ -10,8 +10,8 @@ import { throttle } from 'lodash';
   ctx.globalCompositeOperation = "xor";
 //}
 
-function returnRandom(down,up) {
-  return _.random(down,up,true)
+function returnRandom(down, up) {
+  return random(down, up, true);
 }
 
 
@@ -38,4 +38,4 @@ loop();
 window.addEventListener('resize',function(){
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
-})
+});


### PR DESCRIPTION
## Summary
- use `random` from lodash instead of unused `throttle`
- generate random values without `_.random`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898fc9d464083249f72a33a30d4b2de