### PR TITLE
chore: set up jest testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,15 @@ npm run dev
 npm run preview
 ```
 
+## Testing
+
+Run unit tests with:
+
+```bash
+npm test
+```
+
+
 ## Configuration
 
 ### Physics Parameters

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', {targets: {node: 'current'}}]],
+};

--- a/package.json
+++ b/package.json
@@ -4,16 +4,20 @@
   "description": "",
   "main": "index.js",
   "type": "module",
-  "scripts": {
+    "scripts": {
     "start": "vite",
     "build": "vite build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "@babel/core": "^7.24.0",
+    "@babel/preset-env": "^7.24.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.7.0",

--- a/tests/sample.test.js
+++ b/tests/sample.test.js
@@ -1,0 +1,5 @@
+describe('Sample test', () => {
+  test('adds numbers correctly', () => {
+    expect(1 + 2).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- configure project for Jest unit testing with Babel
- add sample test demonstrating Jest setup
- document how to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898fca374e4832485835dffd8d985c9