### PR TITLE
refactor: centralize random util

### DIFF
--- a/src/js/balls.js
+++ b/src/js/balls.js
@@ -1,3 +1,5 @@
+import { random } from './utils.js';
+
 const selectedBallShapeSelect = document.getElementById('selectedBallShape');
 let sandboxModeEnabled = false;
 const sandboxModeCheckbox = document.getElementById('sandboxMode');
@@ -12,11 +14,6 @@ var ctx = canvas.getContext('2d');
 var width = canvas.width = window.innerWidth;
 var height = canvas.height = window.innerHeight;
 ctx.globalCompositeOperation = "source-over";
-
-function random(min, max) {
-    var num = Math.floor(Math.random() * (max - min + 1)) + min;
-    return num;
-}
 
 function logarithmicSlider(value, min, max) {
     const minp = 0;

--- a/src/js/shape.js
+++ b/src/js/shape.js
@@ -1,6 +1,8 @@
 // https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_building_practice
 // import { throttle } from 'lodash';
 
+import { random } from './utils.js';
+
 document.title = 'shapes';
 
 
@@ -8,11 +10,6 @@ var canvas = document.querySelector('canvas');
 var ctx = canvas.getContext('2d');
 var width = canvas.width = window.innerWidth;
 var height = canvas.height = window.innerHeight;
-
-function random(min, max) {
-    var num = Math.floor(Math.random() * (max - min + 1)) + min;
-    return num;
-}
 
 
 function Shape(x, y, color, size) {

--- a/src/js/square.js
+++ b/src/js/square.js
@@ -1,6 +1,8 @@
 // https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_building_practice
 // import { throttle } from 'lodash';
 
+import { random } from './utils.js';
+
 document.title = 'triangles';
 
 
@@ -8,11 +10,6 @@ var canvas = document.querySelector('canvas');
 var ctx = canvas.getContext('2d');
 var width = canvas.width = window.innerWidth;
 var height = canvas.height = window.innerHeight;
-
-function random(min, max) {
-    var num = Math.floor(Math.random() * (max - min + 1)) + min;
-    return num;
-}
 
 
 function Square(x, y, color, size) {


### PR DESCRIPTION
## Summary
- expose `random` from utils and import across modules
- remove in-file random implementations in balls, square, and shape modules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898fca5137483248a1c0ab8556e2a25